### PR TITLE
fix python dependency name for openstack and ovirt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyvmomi==7.0.3
 aiodns==3.0.0
 setuptools>=62.00.0
 pyyaml==6.0
-openstack
+openstacksdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ aiodns==3.0.0
 setuptools>=62.00.0
 pyyaml==6.0
 openstacksdk
+ovirt-engine-sdk-python


### PR DESCRIPTION
change openstack to openstacksdk in python dependencies
add ovirt-engine-sdk-python